### PR TITLE
281th online meetup 2026-04-04

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,13 @@ Join link: [Google meet](https://meet.google.com/jyx-mxnq-kpk)
 - [269th, 2026-01-10](https://github.com/ThinkAboutSoftware/OnlineSelfCodingGroup/issues/515), joined 4
 - [268th, 2026-01-03](https://github.com/ThinkAboutSoftware/OnlineSelfCodingGroup/issues/514), joined 4
 
-## 2025 4Q meetup list
+<details>
+<summary>Online meet up history</summary>
+<p>
+
+<details>
+<summary>2025년 4Q</summary>
+<p>
 
 - [267th, 2025-12-27](https://github.com/ThinkAboutSoftware/OnlineSelfCodingGroup/issues/511), joined 3
 - [266th, 2025-12-20](https://github.com/ThinkAboutSoftware/OnlineSelfCodingGroup/issues/508), joined 3
@@ -69,9 +75,8 @@ Join link: [Google meet](https://meet.google.com/jyx-mxnq-kpk)
 - [256th, 2025-10-11](https://github.com/ThinkAboutSoftware/OnlineSelfCodingGroup/issues/486), joined 4
 - [255th, 2025-10-04](https://github.com/ThinkAboutSoftware/OnlineSelfCodingGroup/issues/485), joined 4
 
-<details>
-<summary>Online meet up history</summary>
-<p>
+</p>
+</details>
 
 <details>
 <summary>2025년 3Q</summary>

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Join link: [Google meet](https://meet.google.com/jyx-mxnq-kpk)
 - 아무 얘기도 안하고 들어왔을 경우라고 해도 아래 process에 대한 룰은 지켜야 합니다.
 - "XX 때문에 못와서 죄송합니다.", "다음에 꼭 참여할께요" 등 불필요한 변명은 안해도 됩니다. 자율 모임이라 누가 오던 안오던 상관 없는 모임입니다. 각자 알아서 하는 모임이니까요.
 
+## 2026 2Q meetup list
+
+- [281th, 2026-04-04](https://github.com/ThinkAboutSoftware/OnlineSelfCodingGroup/issues/542), joined 3
+
 ## 2026 1Q meetup list
 
 - [280th, 2026-03-28](https://github.com/ThinkAboutSoftware/OnlineSelfCodingGroup/issues/535), joined 3
@@ -495,9 +499,9 @@ and participate more than 30 online meetup, get the chicken gifticon.
 
 |Ranking|Name|Count|
 |-------|----|-----|
-|1|[Kim Jong Feel](https://github.com/jongfeel/)|13|
-|2|[최지윤](https://github.com/chichoon/)|11|
-|3|[Yeshin Lee](https://github.com/yeslee-v/)|6|
+|1|[Kim Jong Feel](https://github.com/jongfeel/)|14|
+|2|[최지윤](https://github.com/chichoon/)|12|
+|3|[Yeshin Lee](https://github.com/yeslee-v/)|7|
 |4|[TaeWon](https://github.com/ytw9699/)|6|
 |5|[LeeDaYeon](https://github.com/ErigoLee/)|5|
 |6|[Daewon Paeng](https://github.com/fora22/)|1|
@@ -509,9 +513,9 @@ and participate more than 30 online meetup, get the chicken gifticon.
 
 |Ranking|Name|Count|
 |-------|----|-----|
-|1|[jongfeel](https://github.com/jongfeel/)|274|
-|2|[최지윤](https://github.com/chichoon)|181|
-|3|[yeslee-v](https://github.com/yeslee-v/)|109|
+|1|[jongfeel](https://github.com/jongfeel/)|275|
+|2|[최지윤](https://github.com/chichoon)|182|
+|3|[yeslee-v](https://github.com/yeslee-v/)|110|
 |4|[Jeongan Lee](https://github.com/fkdl0048/)|51|
 |5|[TaeWon](https://github.com/ytw9699/)|50|
 |6|[Byeongguk Ahn](https://github.com/nonoaa/)|37|

--- a/Stamp/README.md
+++ b/Stamp/README.md
@@ -22,6 +22,14 @@
 
 스탬프를 클릭하면 해당 내용의 issue link로 갈 수 있습니다.
 
+### 2026 2Q, 04-04 (281th) ~ 06-27 (293th)
+
+| Name | 04-04 (281th) | 04-11 (282th) | 04-18 (283th) | 04-25 (284th) | 05-02 (285th) | 05-09 (286th) | 05-16 (287th) | 05-23 (288th) | 05-30 (289th) | 06-06 (290th) | 06-13 (291th) | 06-20 (292th) | 06-27 (293th) |
+|-|-|-|-|-|-|-|-|-|-|-|-|-|-|
+| [Kim Jong Feel](https://github.com/jongfeel/) | <a href="https://github.com/ThinkAboutSoftware/OnlineSelfCodingGroup/issues/542#issuecomment-4185964313"><img src="approved_2021_2Q.png"/></a> | | | | | | | | | | | | |
+| [Yeshin Lee](https://github.com/yeslee-v/) | <a href="https://github.com/ThinkAboutSoftware/OnlineSelfCodingGroup/issues/542#issuecomment-4183362648"><img src="approved_2021_2Q.png"/><img src="Starbucks_americano.JPG"/><img src="approved_2021_2Q.png"/>book 5/20</a> | | | | | | | | | | | | |
+| [최지윤](https://github.com/chichoon) | <a href="https://github.com/ThinkAboutSoftware/OnlineSelfCodingGroup/issues/542#issuecomment-4186186117"><img src="approved_2021_2Q.png"/><img src="approved_2021_2Q.png"/>book 7/20</a> | | | | | | | | | | | | |
+
 ### 2026 1Q, 01-03 (268th) ~ 03-28 (280th)
 
 | Name | 01-03 (268th) | 01-10 (269th) | 01-17 (270th) | 01-24 (271th) | 01-31 (272th) | 02-07 (273th) | 02-14 (274th) | 02-21 (275th) | 02-28 (276th) | 03-07 (277th) | 03-14 (278th) | 03-21 (279th) | 03-28 (280th) |


### PR DESCRIPTION
Closes #542

## Summary
- Update README.md: add 2026 2Q meetup list section with 281th entry (joined 3), increment jongfeel (→14), 최지윤 (→12), Yeshin Lee (→7) in 2026 ranking and all-time ranking
- Update Stamp/README.md: create new 2026 2Q table (281th~293th) with stamps for 281th meetup
  - jongfeel: 1 stamp
  - Yeshin Lee (yeslee-v): 2 stamps + Starbucks (4th multiple reached after 1st stamp), book 5/20
  - 최지윤 (chichoon): 2 stamps (double stamp rule), book 7/20
- Move 2025 4Q meetup list into Online meet up history section wrapped in details/summary/p tags