### PR TITLE
Replace service account with OAuth2 for calendar attendee management

### DIFF
--- a/.github/workflows/add-assignee-to-calendar.yml
+++ b/.github/workflows/add-assignee-to-calendar.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   add-assignee:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     # 모각코 이슈 형식에만 실행 (예: "285th online meetup, 2026-05-02")
     if: ${{ contains(github.event.issue.title, 'online meetup,') }}
 
@@ -21,7 +23,9 @@ jobs:
 
       - name: Add assignee as guest to calendar event
         env:
-          GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+          GOOGLE_OAUTH2_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH2_CLIENT_ID }}
+          GOOGLE_OAUTH2_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH2_CLIENT_SECRET }}
+          GOOGLE_OAUTH2_REFRESH_TOKEN: ${{ secrets.GOOGLE_OAUTH2_REFRESH_TOKEN }}
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
           ASSIGNEE_LOGIN: ${{ github.event.assignee.login }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
@@ -30,7 +34,7 @@ jobs:
         run: |
           python - <<'PYTHON'
           import os, json, time, subprocess
-          from google.oauth2 import service_account
+          from google.oauth2.credentials import Credentials
           from googleapiclient.discovery import build
 
           login = os.environ['ASSIGNEE_LOGIN']
@@ -55,9 +59,12 @@ jobs:
                         f"Add '{login}: <email>' to CALENDAR_EMAIL_MAP variable to enable.")
                   exit(0)
 
-          key_info = json.loads(os.environ['GOOGLE_SERVICE_ACCOUNT_KEY'])
-          credentials = service_account.Credentials.from_service_account_info(
-              key_info, scopes=['https://www.googleapis.com/auth/calendar']
+          credentials = Credentials(
+              token=None,
+              refresh_token=os.environ['GOOGLE_OAUTH2_REFRESH_TOKEN'],
+              client_id=os.environ['GOOGLE_OAUTH2_CLIENT_ID'],
+              client_secret=os.environ['GOOGLE_OAUTH2_CLIENT_SECRET'],
+              token_uri='https://oauth2.googleapis.com/token',
           )
           service = build('calendar', 'v3', credentials=credentials)
           calendar_id = os.environ['GOOGLE_CALENDAR_ID']

--- a/scripts/get_calendar_oauth_token.py
+++ b/scripts/get_calendar_oauth_token.py
@@ -1,0 +1,52 @@
+"""
+One-time script to get Google Calendar OAuth2 refresh token.
+
+Prerequisites:
+  1. Google Cloud Console에서 OAuth2 Client ID 생성 (유형: Desktop app)
+  2. pip install google-auth-oauthlib
+
+Usage:
+  python get_calendar_oauth_token.py <client_id> <client_secret>
+
+After running:
+  출력된 세 값을 GitHub repo secrets에 추가:
+  - GOOGLE_OAUTH2_CLIENT_ID
+  - GOOGLE_OAUTH2_CLIENT_SECRET
+  - GOOGLE_OAUTH2_REFRESH_TOKEN
+"""
+import sys
+from google_auth_oauthlib.flow import InstalledAppFlow
+
+SCOPES = ['https://www.googleapis.com/auth/calendar']
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: python get_calendar_oauth_token.py <client_id> <client_secret>")
+        sys.exit(1)
+
+    client_id, client_secret = sys.argv[1], sys.argv[2]
+
+    flow = InstalledAppFlow.from_client_config(
+        {
+            "installed": {
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "redirect_uris": ["http://localhost"],
+                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                "token_uri": "https://oauth2.googleapis.com/token",
+            }
+        },
+        SCOPES,
+    )
+
+    creds = flow.run_local_server(port=0)
+
+    print("\n--- GitHub Secret Values ---")
+    print(f"GOOGLE_OAUTH2_CLIENT_ID:     {client_id}")
+    print(f"GOOGLE_OAUTH2_CLIENT_SECRET: {client_secret}")
+    print(f"GOOGLE_OAUTH2_REFRESH_TOKEN: {creds.refresh_token}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- `add-assignee-to-calendar.yml`: 서비스 계정 → OAuth2 사용자 인증으로 교체
- `scripts/get_calendar_oauth_token.py`: 일회성 refresh token 발급 헬퍼 스크립트 추가

## 변경 이유
서비스 계정은 Domain-Wide Delegation 없이 캘린더 참석자를 초대할 수 없으며, 개인 Google 계정에서는 DWD를 사용할 수 없습니다.

## 사전 작업 (PR merge 후 필요)
1. [Google Cloud Console](https://console.cloud.google.com/) → APIs & Services → Credentials
2. **OAuth2 Client ID** 생성 (유형: **Desktop app**)
3. 로컬에서 헬퍼 스크립트 실행:
   ```bash
   pip install google-auth-oauthlib
   python scripts/get_calendar_oauth_token.py <client_id> <client_secret>
   ```
4. 브라우저에서 jongfeel Google 계정으로 인증
5. 출력된 세 값을 GitHub repo secrets에 추가:
   - `GOOGLE_OAUTH2_CLIENT_ID`
   - `GOOGLE_OAUTH2_CLIENT_SECRET`
   - `GOOGLE_OAUTH2_REFRESH_TOKEN`

## Test plan
- [ ] 헬퍼 스크립트로 refresh token 발급 확인
- [ ] GitHub secrets 설정 후 issue assigned 이벤트로 워크플로우 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)